### PR TITLE
Add GitHub Actions workflow to build Windows and macOS desktop installers

### DIFF
--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -1,0 +1,198 @@
+name: Build Desktop Installers
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows-exe:
+    name: Build Windows EXE
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17 (includes jpackage)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Build runnable JAR with Ant
+        run: ant -noinput -buildfile build.xml dist
+
+      - name: Verify JAR output
+        shell: pwsh
+        run: |
+          if (-not (Test-Path "dist/onyx.jar")) {
+            Write-Error "Expected dist/onyx.jar was not produced by Ant build."
+            exit 1
+          }
+
+      - name: Prepare Windows icon
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path build/package -Force | Out-Null
+          $png = [System.IO.File]::ReadAllBytes("src/images/onyx-taskbar.png")
+          $header = [byte[]](0, 0, 1, 0, 1, 0)
+          $entry = New-Object byte[] 16
+          $entry[0] = 126
+          $entry[1] = 128
+          $entry[2] = 0
+          $entry[3] = 0
+          $entry[4] = 1
+          $entry[5] = 0
+          $entry[6] = 32
+          $entry[7] = 0
+          [BitConverter]::GetBytes([UInt32]$png.Length).CopyTo($entry, 8)
+          [BitConverter]::GetBytes([UInt32]22).CopyTo($entry, 12)
+          [System.IO.File]::WriteAllBytes("build/package/onyx.ico", $header + $entry + $png)
+
+      - name: Package Windows EXE with jpackage
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path dist/windows -Force | Out-Null
+          jpackage `
+            --type exe `
+            --name Onyx `
+            --input dist `
+            --main-jar onyx.jar `
+            --main-class Main `
+            --icon build/package/onyx.ico `
+            --dest dist/windows
+
+      - name: Upload Windows executable artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Onyx-Windows-EXE
+          path: dist/windows/*.exe
+          if-no-files-found: error
+
+  build-macos-app:
+    name: Build macOS App
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17 (includes jpackage)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Build runnable JAR with Ant
+        run: ant -noinput -buildfile build.xml dist
+
+      - name: Verify JAR output
+        run: |
+          if [ ! -f dist/onyx.jar ]; then
+            echo "Expected dist/onyx.jar was not produced by Ant build." >&2
+            exit 1
+          fi
+
+      - name: Prepare macOS icon
+        run: |
+          mkdir -p build/package/Onyx.iconset
+          sips -z 16 16 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_16x16.png
+          sips -z 32 32 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_16x16@2x.png
+          sips -z 32 32 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_32x32.png
+          sips -z 64 64 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_32x32@2x.png
+          sips -z 128 128 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_128x128.png
+          sips -z 256 256 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_128x128@2x.png
+          sips -z 256 256 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_256x256.png
+          sips -z 512 512 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_256x256@2x.png
+          sips -z 512 512 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_512x512.png
+          sips -z 1024 1024 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_512x512@2x.png
+          iconutil -c icns build/package/Onyx.iconset -o build/package/Onyx.icns
+
+      - name: Package macOS app-image with jpackage
+        run: |
+          mkdir -p dist/macos-app
+          jpackage \
+            --type app-image \
+            --name Onyx \
+            --input dist \
+            --main-jar onyx.jar \
+            --main-class Main \
+            --java-options "-XstartOnFirstThread" \
+            --icon build/package/Onyx.icns \
+            --dest dist/macos-app
+
+      - name: Upload macOS executable artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Onyx-macOS-App
+          path: dist/macos-app/Onyx.app
+          if-no-files-found: error
+
+  build-macos-dmg:
+    name: Build macOS DMG
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17 (includes jpackage)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Build runnable JAR with Ant
+        run: ant -noinput -buildfile build.xml dist
+
+      - name: Verify JAR output
+        run: |
+          if [ ! -f dist/onyx.jar ]; then
+            echo "Expected dist/onyx.jar was not produced by Ant build." >&2
+            exit 1
+          fi
+
+      - name: Prepare macOS icon
+        run: |
+          mkdir -p build/package/Onyx.iconset
+          sips -z 16 16 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_16x16.png
+          sips -z 32 32 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_16x16@2x.png
+          sips -z 32 32 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_32x32.png
+          sips -z 64 64 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_32x32@2x.png
+          sips -z 128 128 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_128x128.png
+          sips -z 256 256 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_128x128@2x.png
+          sips -z 256 256 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_256x256.png
+          sips -z 512 512 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_256x256@2x.png
+          sips -z 512 512 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_512x512.png
+          sips -z 1024 1024 src/images/onyx-taskbar.png --out build/package/Onyx.iconset/icon_512x512@2x.png
+          iconutil -c icns build/package/Onyx.iconset -o build/package/Onyx.icns
+
+      - name: Package macOS DMG with jpackage
+        run: |
+          mkdir -p dist/macos
+          jpackage \
+            --type dmg \
+            --name Onyx \
+            --input dist \
+            --main-jar onyx.jar \
+            --main-class Main \
+            --java-options "-XstartOnFirstThread" \
+            --icon build/package/Onyx.icns \
+            --dest dist/macos
+
+      - name: Upload macOS DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Onyx-macOS-DMG
+          path: dist/macos/*.dmg
+          if-no-files-found: error


### PR DESCRIPTION
### Motivation

- Provide automated packaging and installer artifacts for the Onyx desktop application for Windows and macOS.
- Use `jpackage` and the existing Ant build to produce redistributable `.exe`, `.app` (app-image) and `.dmg` outputs.

### Description

- Add a new workflow file `/.github/workflows/desktop-installers.yml` that triggers on `push`, `pull_request`, and `workflow_dispatch` and sets `contents: read` permissions.
- Introduce three jobs: `build-windows-exe`, `build-macos-app`, and `build-macos-dmg`, each using JDK 17 via `actions/setup-java@v4` and building the runnable JAR with `ant -noinput -buildfile build.xml dist`.
- Implement platform-specific icon preparation: a PowerShell-based `.ico` assembly for Windows and `sips` + `iconutil` iconset conversion to `.icns` for macOS, and then package using `jpackage` for `--type exe`, `--type app-image`, and `--type dmg` respectively.
- Upload produced artifacts using `actions/upload-artifact@v4` as `Onyx-Windows-EXE`, `Onyx-macOS-App`, and `Onyx-macOS-DMG` with explicit error-on-missing-file behavior.

### Testing

- No automated tests were executed as part of this PR; the workflow can be validated by triggering the `workflow_dispatch` or by pushing to `main`/`master` to observe artifact production in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b17160dad0832cb4ddee525dcf033e)