### PR TITLE
Fix Ant release setting and add JAR-content checks in desktop installers workflow

### DIFF
--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -39,6 +39,11 @@ jobs:
             Write-Error "Expected dist/onyx.jar was not produced by Ant build."
             exit 1
           }
+          $classCount = (& jar tf "dist/onyx.jar" | Select-String "\.class$").Count
+          if ($classCount -eq 0) {
+            Write-Error "dist/onyx.jar does not contain any compiled .class files."
+            exit 1
+          }
 
       - name: Prepare Windows icon
         shell: pwsh
@@ -100,6 +105,10 @@ jobs:
         run: |
           if [ ! -f dist/onyx.jar ]; then
             echo "Expected dist/onyx.jar was not produced by Ant build." >&2
+            exit 1
+          fi
+          if ! jar tf dist/onyx.jar | grep -q '\.class$'; then
+            echo "dist/onyx.jar does not contain any compiled .class files." >&2
             exit 1
           fi
 

--- a/build.xml
+++ b/build.xml
@@ -3,8 +3,7 @@
 <project default="dist" 
 name="Create Runnable Jar for Project Onyx" xmlns:ivy="antlib:org.apache.ivy.ant">
 
-	<property name="java.version" value="9"/>
-	<property name="src.version" value="1.9"/>
+	<property name="javac.release" value="9"/>
 
 	<property name="src" location="src" />
 	<property name="lib" location="lib" />
@@ -27,7 +26,7 @@ name="Create Runnable Jar for Project Onyx" xmlns:ivy="antlib:org.apache.ivy.ant
 
 
 		<!-- Compile the java code from ${src} into ${build} -->
-		<javac srcdir="${src}" destdir="${build}" debug="true" 	release="${java.version}" source="${src.version}" target="${src.version}" encoding="iso-8859-1" failonerror="false">
+		<javac srcdir="${src}" destdir="${build}" debug="true" release="${javac.release}" encoding="iso-8859-1" includeantruntime="false" failonerror="true">
 			<classpath>
 				<pathelement path="lib/gral-core-0.11.jar"/>
 				<pathelement path="lib/junit-4.13.2.jar"/>


### PR DESCRIPTION
### Motivation
- Prevent `javac --release` from receiving a JVM `java.version` (e.g. `17.0.18`) which causes compilation errors.
- Make the Ant compile task fail the build on real compiler errors and avoid leaking Ant runtime jars into the compiler classpath for repeatable builds.
- Stop `jpackage` from running when the produced `dist/onyx.jar` exists but contains no compiled `.class` files to avoid producing broken installers.

### Description
- Rename the Ant property to `javac.release` and use it for the `<javac>` `release` attribute instead of the JVM-provided `java.version`. 
- Remove redundant `source`/`target` attributes, set `failonerror="true"` and add `includeantruntime="false"` on the `<javac>` task in `build.xml` to hard-fail on compilation errors and use a clean compiler classpath. 
- Add verification steps in `.github/workflows/desktop-installers.yml` for Windows and macOS that assert `dist/onyx.jar` contains `.class` entries and fail early if the JAR has no compiled classes. 

### Testing
- Executed the Ant build via `java -cp ... ant-launcher ... -buildfile build.xml dist` which completed successfully and produced `dist/onyx.jar`. (succeeded)
- Verified compiled class count with `jar tf dist/onyx.jar | rg '\.class$' | wc -l` which reported `606` class entries. (succeeded)
- Parsed `build.xml` with `python3` XML parsing and validated the modified workflow YAML with Ruby `YAML.load_file`, both of which parsed successfully. (succeeded)
- Attempts to install system `ant` with `apt-get` and to run `mvn -q -DskipTests compile` were blocked by repository/proxy HTTP 403 errors in the environment and could not be completed. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01892d6880832c95a8ca0b652c34a8)