### PR TITLE
Add ordinal (threshold) variable support: model, likelihood, UI and remapping

### DIFF
--- a/src/engine/ModelRequestInterface.java
+++ b/src/engine/ModelRequestInterface.java
@@ -51,6 +51,12 @@ public interface ModelRequestInterface {
 
 	public void requestSwapLatentToManifest(Node node);
 
+	/**
+	 * Marks an observed variable as ordinal and supplies its latent-response
+	 * thresholds. Thresholds are ignored when ordinal is false.
+	 */
+	public void requestSetOrdinalVariable(Node node, boolean ordinal, double[] thresholds);
+
 	
 	/**
 	 * request a change of the model name

--- a/src/engine/OnyxModel.java
+++ b/src/engine/OnyxModel.java
@@ -332,6 +332,7 @@ public class OnyxModel extends RAMModel implements ModelRequestInterface {
         if (!node.isLatent()) {
             filter[anzVar] = anzFac-1;
             anzVar++;
+            if (node.isOrdinal()) setOrdinalVariable(anzVar-1, true, node.getOrdinalThresholds());
         }
 
         node.setId(anzFac-1);
@@ -341,6 +342,7 @@ public class OnyxModel extends RAMModel implements ModelRequestInterface {
     }
 
     public synchronized void requestSwapLatentToManifest(Node node) {
+        int[] oldFilter = filter;
         anzVar += (node.isLatent()?+1:-1);
         int[] nFilter = new int[anzVar];
         
@@ -351,10 +353,28 @@ public class OnyxModel extends RAMModel implements ModelRequestInterface {
         } else {
             Statik.subvector(filter, nFilter, node.getId());
         }
+        int[] ordinalSources = new int[nFilter.length];
+        for (int i=0; i<nFilter.length; i++) {
+            ordinalSources[i] = -1;
+            for (int j=0; j<oldFilter.length; j++) if (oldFilter[j] == nFilter[i]) {ordinalSources[i] = j; break;}
+        }
+        remapOrdinalVariables(ordinalSources);
         filter = nFilter;
         
         for (int i=0; i<modelListener.length; i++) modelListener[i].swapLatentToManifest(node);
         invalidateDataSet(); modelRun.requestReset();
+    }
+
+    @Override
+    public synchronized void requestSetOrdinalVariable(Node node, boolean ordinal, double[] thresholds) {
+        if (!node.isObserved()) throw new IllegalArgumentException("Only observed variables can be ordinal.");
+        int observedIndex = -1;
+        for (int i=0; i<filter.length; i++) if (filter[i] == node.getId()) { observedIndex = i; break; }
+        if (observedIndex == -1) throw new IllegalArgumentException("Node is not an observed model variable.");
+        setOrdinalVariable(observedIndex, ordinal, thresholds);
+        node.setOrdinal(ordinal, thresholds);
+        invalidateDataSet();
+        modelRun.requestReset();
     }
 
     public synchronized boolean requestCycleArrowHeads(Edge edge) {

--- a/src/engine/backend/Model.java
+++ b/src/engine/backend/Model.java
@@ -95,6 +95,16 @@ public abstract class Model
       public double[] mu;
       public double sigmaDet;
 
+      /*
+       * Measurement scale metadata.  An ordinal observation is assumed to be a
+       * zero-based category of a latent Gaussian response.  Its thresholds are
+       * the (strictly increasing) finite cut points between categories; hence
+       * k thresholds describe k + 1 categories.  Keeping this on Model rather
+       * than on RAMModel also makes the likelihood available to its wrappers.
+       */
+      protected boolean[] ordinalVariables;
+      protected double[][] ordinalThresholds;
+
       public enum Objective {maximumLikelihood, Leastsquares};
       public Objective fitFunction;                       // remembers last initialization of fit process with ml or ls
       public enum Strategy {classic, defaul, user, defaultWithEMSupport, MCMC};
@@ -178,6 +188,47 @@ public abstract class Model
       
       public int getAnzPar() {return anzPar = paraNames.length;}
       public int getAnzVar() {return anzVar;}
+
+      /** Marks an observed variable as ordinal and supplies its latent-response cut points. */
+      public void setOrdinalVariable(int variable, boolean ordinal, double[] thresholds) {
+          if (variable < 0 || variable >= anzVar) throw new IllegalArgumentException("Unknown observed variable: "+variable);
+          if (ordinal && thresholds == null) throw new IllegalArgumentException("Ordinal variables require thresholds.");
+          if (ordinal) {
+              for (int i=0; i<thresholds.length; i++) {
+                  if (!Double.isFinite(thresholds[i]) || (i > 0 && thresholds[i] <= thresholds[i-1]))
+                      throw new IllegalArgumentException("Ordinal thresholds must be finite and strictly increasing.");
+              }
+          }
+          if (ordinalVariables == null || ordinalVariables.length != anzVar) ordinalVariables = new boolean[anzVar];
+          if (ordinalThresholds == null || ordinalThresholds.length != anzVar) ordinalThresholds = new double[anzVar][];
+          ordinalVariables[variable] = ordinal;
+          ordinalThresholds[variable] = ordinal ? Arrays.copyOf(thresholds, thresholds.length) : null;
+      }
+
+      public boolean isOrdinalVariable(int variable) {return ordinalVariables != null && ordinalVariables[variable];}
+      public double[] getOrdinalThresholds(int variable) {
+          return ordinalThresholds == null || ordinalThresholds[variable] == null ? null : Arrays.copyOf(ordinalThresholds[variable], ordinalThresholds[variable].length);
+      }
+      protected boolean hasOrdinalVariables() {
+          if (ordinalVariables != null) for (boolean ordinal : ordinalVariables) if (ordinal) return true;
+          return false;
+      }
+
+      /** Reorders ordinal metadata after an observed-variable filter changes. */
+      public void remapOrdinalVariables(int[] sourceIndices) {
+          if (ordinalVariables == null) return;
+          boolean[] remappedFlags = new boolean[sourceIndices.length];
+          double[][] remappedThresholds = new double[sourceIndices.length][];
+          for (int i=0; i<sourceIndices.length; i++) {
+              int source = sourceIndices[i];
+              if (source >= 0 && source < ordinalVariables.length) {
+                  remappedFlags[i] = ordinalVariables[source];
+                  remappedThresholds[i] = ordinalThresholds[source] == null ? null : Arrays.copyOf(ordinalThresholds[source], ordinalThresholds[source].length);
+              }
+          }
+          ordinalVariables = remappedFlags;
+          ordinalThresholds = remappedThresholds;
+      }
 
       /** copies this */
       public abstract Model copy(); 
@@ -522,6 +573,7 @@ public abstract class Model
 
           if (value != null) setParameter(value);
           if (recomputeMuAndSigma) evaluateMuAndSigma(value);
+          if (hasOrdinalVariables()) return getJointOrdinalContinuousMinusTwoLogLikelihood();
         
           if (anzVar == 0) {
               sigmaDet = Double.NaN; ll = Double.NaN; 
@@ -558,6 +610,108 @@ public abstract class Model
           }
           
         return ll;
+    }
+
+    /**
+     * Full-information likelihood for a mixture of Gaussian continuous
+     * observations and thresholded Gaussian ordinal observations.  Continuous
+     * values are evaluated as a marginal density and ordinal values as a
+     * conditional normal rectangle probability.  The latter uses deterministic
+     * GHK integration, so the objective remains reproducible for numerical
+     * optimization and supports correlated ordinal responses.
+     */
+    private double getJointOrdinalContinuousMinusTwoLogLikelihood() {
+        if (data == null) throw new IllegalStateException("Joint ordinal likelihood requires raw data.");
+        double result = 0.0;
+        for (double[] row : data) {
+            int[] continuous = observedIndices(row, false);
+            int[] ordinal = observedIndices(row, true);
+            if (continuous.length == 0 && ordinal.length == 0) continue;
+            double logProbability = continuousLogDensity(row, continuous);
+            if (ordinal.length > 0) logProbability += Math.log(ordinalProbability(row, continuous, ordinal));
+            result -= 2.0 * logProbability;
+        }
+        ll = result;
+        return result;
+    }
+
+    private int[] observedIndices(double[] row, boolean ordinal) {
+        int count = 0;
+        for (int i=0; i<anzVar; i++) if (isOrdinalVariable(i) == ordinal && !isMissing(row[i])) count++;
+        int[] indices = new int[count]; int p = 0;
+        for (int i=0; i<anzVar; i++) if (isOrdinalVariable(i) == ordinal && !isMissing(row[i])) indices[p++] = i;
+        return indices;
+    }
+
+    private double continuousLogDensity(double[] row, int[] continuous) {
+        if (continuous.length == 0) return 0.0;
+        double[][] covariance = submatrix(sigma, continuous, continuous);
+        double[][] inverse = new double[continuous.length][continuous.length];
+        double determinant;
+        try {determinant = Statik.invert(covariance, inverse, new double[1]);}
+        catch (RuntimeException e) {return Double.NEGATIVE_INFINITY;}
+        if (!(determinant > 0.0)) return Double.NEGATIVE_INFINITY;
+        double quadratic = 0.0;
+        for (int i=0; i<continuous.length; i++) for (int j=0; j<continuous.length; j++)
+            quadratic += (row[continuous[i]]-mu[continuous[i]]) * inverse[i][j] * (row[continuous[j]]-mu[continuous[j]]);
+        return -0.5 * (continuous.length * LNTWOPI + Math.log(determinant) + quadratic);
+    }
+
+    private double ordinalProbability(double[] row, int[] continuous, int[] ordinal) {
+        double[] conditionalMean = new double[ordinal.length];
+        double[][] conditionalCovariance = submatrix(sigma, ordinal, ordinal);
+        for (int i=0; i<ordinal.length; i++) conditionalMean[i] = mu[ordinal[i]];
+        if (continuous.length > 0) {
+            double[][] cc = submatrix(sigma, continuous, continuous), ccInverse = new double[continuous.length][continuous.length];
+            if (!(Statik.invert(cc, ccInverse, new double[1]) > 0.0)) return 0.0;
+            double[][] oc = submatrix(sigma, ordinal, continuous), co = submatrix(sigma, continuous, ordinal);
+            double[] delta = new double[continuous.length];
+            for (int i=0; i<delta.length; i++) delta[i] = row[continuous[i]] - mu[continuous[i]];
+            for (int i=0; i<ordinal.length; i++) for (int j=0; j<continuous.length; j++) for (int k=0; k<continuous.length; k++)
+                conditionalMean[i] += oc[i][j] * ccInverse[j][k] * delta[k];
+            for (int i=0; i<ordinal.length; i++) for (int j=0; j<ordinal.length; j++) for (int k=0; k<continuous.length; k++) for (int l=0; l<continuous.length; l++)
+                conditionalCovariance[i][j] -= oc[i][k] * ccInverse[k][l] * co[l][j];
+        }
+        double[][] lower = cholesky(conditionalCovariance);
+        if (lower == null) return 0.0;
+        double probability = 0.0;
+        for (int draw=1; draw<=128; draw++) {
+            double[] z = new double[ordinal.length]; double weight = 1.0;
+            for (int i=0; i<ordinal.length; i++) {
+                int category = checkedCategory(row[ordinal[i]], ordinal[i]);
+                double location = conditionalMean[i]; for (int j=0; j<i; j++) location += lower[i][j]*z[j];
+                double lowerBound = category == 0 ? Double.NEGATIVE_INFINITY : ordinalThresholds[ordinal[i]][category-1];
+                double upperBound = category == ordinalThresholds[ordinal[i]].length ? Double.POSITIVE_INFINITY : ordinalThresholds[ordinal[i]][category];
+                double a = normalCdf((lowerBound-location)/lower[i][i]);
+                double b = normalCdf((upperBound-location)/lower[i][i]);
+                double mass = Math.max(1e-300, b-a); weight *= mass;
+                z[i] = inverseNormal(a + mass * halton(draw, i));
+            }
+            probability += weight;
+        }
+        return Math.max(1e-300, probability / 128.0);
+    }
+
+    private int checkedCategory(double value, int variable) {
+        int category = (int)Math.rint(value);
+        if (Math.abs(value-category) > 1e-9 || category < 0 || category > ordinalThresholds[variable].length)
+            throw new IllegalArgumentException("Ordinal value "+value+" is outside the categories for variable "+variable);
+        return category;
+    }
+    private static double[][] submatrix(double[][] matrix, int[] rows, int[] columns) { double[][] r = new double[rows.length][columns.length]; for(int i=0;i<rows.length;i++) for(int j=0;j<columns.length;j++) r[i][j]=matrix[rows[i]][columns[j]]; return r; }
+    private static double[][] cholesky(double[][] a) { int n=a.length; double[][] l=new double[n][n]; for(int i=0;i<n;i++) for(int j=0;j<=i;j++){ double s=a[i][j]; for(int k=0;k<j;k++) s-=l[i][k]*l[j][k]; if(i==j){if(s<=0)return null;l[i][j]=Math.sqrt(s);}else l[i][j]=s/l[j][j]; } return l; }
+    private static double halton(int index, int dimension) { int[] bases={2,3,5,7,11,13,17,19,23,29}; int base=bases[dimension%bases.length], n=index; double f=1.0, r=0.0; while(n>0){f/=base;r+=f*(n%base);n/=base;} return r; }
+    private static double normalCdf(double x) { if(x==Double.NEGATIVE_INFINITY)return 0; if(x==Double.POSITIVE_INFINITY)return 1; double t=1/(1+0.2316419*Math.abs(x)); double p=1-0.3989422804014327*Math.exp(-x*x/2)*t*(0.319381530+t*(-0.356563782+t*(1.781477937+t*(-1.821255978+t*1.330274429)))); return x<0?1-p:p; }
+    private static double inverseNormal(double p) { // Peter J. Acklam's rational approximation
+        p=Math.max(1e-15,Math.min(1-1e-15,p));
+        double[] a={-39.69683028665376,220.9460984245205,-275.9285104469687,138.357751867269,-30.66479806614716,2.506628277459239};
+        double[] b={-54.47609879822406,161.5858368580409,-155.6989798598866,66.80131188771972,-13.28068155288572};
+        double[] c={-0.007784894002430293,-0.3223964580411365,-2.400758277161838,-2.549732539343734,4.374664141464968,2.938163982698783};
+        double[] d={0.007784695709041462,0.3224671290700398,2.445134137142996,3.754408661907416};
+        double q, r;
+        if (p < .02425) { q=Math.sqrt(-2*Math.log(p)); return (((((c[0]*q+c[1])*q+c[2])*q+c[3])*q+c[4])*q+c[5])/((((d[0]*q+d[1])*q+d[2])*q+d[3])*q+1); }
+        if (p > .97575) { q=Math.sqrt(-2*Math.log(1-p)); return -(((((c[0]*q+c[1])*q+c[2])*q+c[3])*q+c[4])*q+c[5])/((((d[0]*q+d[1])*q+d[2])*q+d[3])*q+1); }
+        q=p-.5; r=q*q; return (((((a[0]*r+a[1])*r+a[2])*r+a[3])*r+a[4])*r+a[5])*q/(((((b[0]*r+b[1])*r+b[2])*r+b[3])*r+b[4])*r+1);
     }
       /**
        * Returns the standard deviation of the parameter estimates as the diagonal elements of the inverted Hessian.

--- a/src/engine/backend/RAMModel.java
+++ b/src/engine/backend/RAMModel.java
@@ -123,6 +123,8 @@ public class RAMModel extends NumericalDerivativeModel {
         this.paraNames = Statik.copy(toCopy.paraNames);
         this.position = Statik.copy(toCopy.position);
         this.anzPar = toCopy.anzPar;
+        if (toCopy.ordinalVariables != null) this.ordinalVariables = Statik.copy(toCopy.ordinalVariables);
+        if (toCopy.ordinalThresholds != null) this.ordinalThresholds = Statik.copy(toCopy.ordinalThresholds);
         if (toCopy.isIndirectData) this.setDataDistribution(toCopy.dataCov, toCopy.dataMean, toCopy.anzPer); 
         else this.setData(Statik.copy(toCopy.data), Statik.copy(toCopy.auxiliaryData), Statik.copy(toCopy.controlData));
         this.filter = Statik.copy(toCopy.filter); 
@@ -412,7 +414,9 @@ public class RAMModel extends NumericalDerivativeModel {
     public boolean debugGradientAndHessianComputationIsNumerical = false;
     public void computeLogLikelihoodDerivatives(double[] value, boolean recomputeMuAndSigma) {
         callCount++;
-        if (debugGradientAndHessianComputationIsNumerical) super.computeLogLikelihoodDerivatives(value, recomputeMuAndSigma);
+        // Threshold likelihoods use conditional rectangle probabilities and
+        // therefore require numerical derivatives until analytic GHK scores are supplied.
+        if (debugGradientAndHessianComputationIsNumerical || hasOrdinalVariables()) super.computeLogLikelihoodDerivatives(value, recomputeMuAndSigma);
         else correctComputeLogLikelihoodDerivatives(value, recomputeMuAndSigma);        
     }
     
@@ -823,8 +827,7 @@ public class RAMModel extends NumericalDerivativeModel {
 
     @Override
     public Model copy() {
-        return new RAMModel(Statik.copy(symPar), Statik.copy(symVal), Statik.copy(asyPar), Statik.copy(asyVal), Statik.copy(meanPar), 
-                Statik.copy(meanVal), Statik.copy(filter));
+        return new RAMModel(this);
     }
 
     @Override
@@ -893,6 +896,12 @@ public class RAMModel extends NumericalDerivativeModel {
     public RAMModel removeObservation(int obs) {
         RAMModel copy = new RAMModel((RAMModel)this);
         copy.filter = Statik.subvector(copy.filter, obs);
+        if (copy.ordinalVariables != null) copy.ordinalVariables = Statik.subvector(copy.ordinalVariables, obs);
+        if (copy.ordinalThresholds != null) {
+            double[][] thresholds = new double[copy.ordinalThresholds.length-1][];
+            for (int i=0, j=0; i<copy.ordinalThresholds.length; i++) if (i != obs) thresholds[j++] = copy.ordinalThresholds[i];
+            copy.ordinalThresholds = thresholds;
+        }
         copy.anzVar--;
         return copy;
     }

--- a/src/gui/graph/Node.java
+++ b/src/gui/graph/Node.java
@@ -85,6 +85,10 @@ public class Node implements Cloneable, FillColorable, LineColorable, Movable, R
 	private boolean multiplication = false;
 
 	private boolean isNormalized = false;
+	// Threshold-model metadata for observed variables.  Thresholds are in the
+	// latent-response scale and define zero-based ordinal categories.
+	private boolean ordinal = false;
+	private double[] ordinalThresholds;
 
 	// Depth of the node in the graph object. Needs to be set using the
 	// computeDirectedDephts in the Graph class.
@@ -220,6 +224,7 @@ public class Node implements Cloneable, FillColorable, LineColorable, Movable, R
 			node.groupingVariableContainer.addVariableContainerListener(node);
 			node.observedVariableContainer = (VariableContainer) observedVariableContainer.clone(node);
 			node.observedVariableContainer.addVariableContainerListener(node);
+			node.ordinalThresholds = ordinalThresholds == null ? null : ordinalThresholds.clone();
 			return (node);
 		} catch (CloneNotSupportedException e) {
 			// TODO Auto-generated catch block
@@ -227,6 +232,17 @@ public class Node implements Cloneable, FillColorable, LineColorable, Movable, R
 			return (null);
 		}
 
+	}
+
+	public boolean isOrdinal() { return ordinal; }
+
+	public double[] getOrdinalThresholds() {
+		return ordinalThresholds == null ? null : ordinalThresholds.clone();
+	}
+
+	public void setOrdinal(boolean ordinal, double[] thresholds) {
+		this.ordinal = ordinal;
+		this.ordinalThresholds = ordinal && thresholds != null ? thresholds.clone() : null;
 	}
 
 	public boolean isNormalized() {

--- a/src/gui/views/ModelView.java
+++ b/src/gui/views/ModelView.java
@@ -554,6 +554,7 @@ public class ModelView extends View implements ModelListener, ActionListener, Dr
 	private JMenuItem menuSwapManifestLatent;
 
 	private JMenuItem menuSwapNormalized;
+	private JCheckBoxMenuItem menuSetOrdinal;
 	private JMenuItem menuResetToDefaults;
 	private JMenuItem menuToggleAutomaticNaming;
 
@@ -1127,6 +1128,28 @@ public class ModelView extends View implements ModelListener, ActionListener, Dr
 				node.setNormalized(!state);
 
 			this.modelChangedEvent();
+			this.redraw();
+		}
+
+		if (e.getSource() == menuSetOrdinal) {
+			if (menuSetOrdinal.isSelected()) {
+				String current = formatOrdinalThresholds(menuContextNode.getOrdinalThresholds());
+				String input = JOptionPane.showInputDialog(this,
+						"Latent-response thresholds (comma separated; categories are zero-based):",
+						current.length() == 0 ? "0" : current);
+				if (input == null) {
+					menuSetOrdinal.setSelected(false);
+					return;
+				}
+				try {
+					getModelRequestInterface().requestSetOrdinalVariable(menuContextNode, true, parseOrdinalThresholds(input));
+				} catch (IllegalArgumentException exception) {
+					menuSetOrdinal.setSelected(false);
+					JOptionPane.showMessageDialog(this, exception.getMessage(), "Invalid ordinal thresholds", JOptionPane.ERROR_MESSAGE);
+				}
+			} else {
+				getModelRequestInterface().requestSetOrdinalVariable(menuContextNode, false, null);
+			}
 			this.redraw();
 		}
 
@@ -5057,6 +5080,25 @@ public class ModelView extends View implements ModelListener, ActionListener, Dr
 		}
 	}
 
+	private static double[] parseOrdinalThresholds(String input) {
+		String[] parts = input.trim().split("\\s*,\\s*");
+		if (parts.length == 0 || (parts.length == 1 && parts[0].isEmpty()))
+			throw new IllegalArgumentException("Provide at least one threshold.");
+		double[] thresholds = new double[parts.length];
+		for (int i=0; i<parts.length; i++) thresholds[i] = Double.parseDouble(parts[i]);
+		return thresholds;
+	}
+
+	private static String formatOrdinalThresholds(double[] thresholds) {
+		if (thresholds == null) return "";
+		StringBuilder text = new StringBuilder();
+		for (int i=0; i<thresholds.length; i++) {
+			if (i > 0) text.append(", ");
+			text.append(thresholds[i]);
+		}
+		return text.toString();
+	}
+
 	private void populateMenu(MouseEvent arg0) {
 		menu = new JPopupMenu();
 
@@ -5134,6 +5176,10 @@ public class ModelView extends View implements ModelListener, ActionListener, Dr
 								.getCurrentNodeState().getFontSize();
 						boolean nameChanged = !pendingNode.getPreviousNodeState().getCaption()
 								.equals(pendingNode.getCurrentNodeState().getCaption());
+						boolean ordinalChanged = pendingNode.getPreviousNodeState().isOrdinal() != pendingNode
+								.getCurrentNodeState().isOrdinal()
+								|| !Arrays.equals(pendingNode.getPreviousNodeState().getOrdinalThresholds(),
+										pendingNode.getCurrentNodeState().getOrdinalThresholds());
 
 						// System.out.println(pendingNode.getPreviousNodeState().getCaption()+"
 						// "+fontSizeChanged+" "+nameChanged);
@@ -5147,6 +5193,7 @@ public class ModelView extends View implements ModelListener, ActionListener, Dr
 							MainFrame.undoStack.add(new NodeRenameStep(getModelRequestInterface(), menuContextNode,
 									pendingNode.getPreviousNodeState().getCaption()));
 						}
+						if (ordinalChanged) MainFrame.undoStack.add(pendingNode);
 
 					}
 
@@ -5270,6 +5317,13 @@ public class ModelView extends View implements ModelListener, ActionListener, Dr
 			menu.add(menuSwapLatent);
 
 			if (menuContextNode.isManifest()) {
+				if (menuSetOrdinal == null) {
+					menuSetOrdinal = new JCheckBoxMenuItem("Ordinal variable");
+					menuSetOrdinal.addActionListener(this);
+				}
+				menuSetOrdinal.setSelected(menuContextNode.isOrdinal());
+				menu.add(menuSetOrdinal);
+
 				if (menuSwapGrouping == null) {
 					menuSwapGrouping = new JMenuItem("");
 					menuSwapGrouping.addActionListener(this);


### PR DESCRIPTION
### Motivation

- Add support for observed ordinal variables represented as thresholded latent responses so the model can handle mixed continuous/ordinal data and compute correct likelihoods. 
- Ensure ordinal metadata remains consistent when the observed-variable filter changes (e.g. swapping latent/manifest). 
- Expose UI controls to mark an observed variable as ordinal and set its thresholds.

### Description

- Introduces an ordinal API to the model layer: added `setOrdinalVariable`, `isOrdinalVariable`, `getOrdinalThresholds`, `hasOrdinalVariables`, and `remapOrdinalVariables` to `Model`, and a new `requestSetOrdinalVariable` to `ModelRequestInterface` and `OnyxModel` that validates and applies ordinal settings and triggers dataset invalidation/reset via `modelRun.requestReset()`.
- Implements full-information mixed continuous/ordinal likelihood evaluation in `Model.getMinusTwoLogLikelihood` by dispatching to `getJointOrdinalContinuousMinusTwoLogLikelihood()` when ordinal variables are present; the implementation computes continuous marginal densities and conditional ordinal rectangle probabilities using deterministic GHK-style integration (Halton draws), LDL/Cholesky helpers, standard normal CDF and inverse approximations, and protective checks for positive-definiteness and finite thresholds.
- Ensures derivatives are handled numerically for threshold likelihoods by forcing numerical gradient/Hessian computation when `hasOrdinalVariables()` in `RAMModel.computeLogLikelihoodDerivatives`.
- Adds ordinal metadata to backend data structures: `ordinalVariables` and `ordinalThresholds` fields on `Model`, copies/remaps in `RAMModel` constructors and `removeObservation`, and remapping when the observed-variable `filter` changes in `OnyxModel.requestSwapLatentToManifest`.
- Adds Node-level metadata and API: `ordinal` flag plus `ordinalThresholds`, accessor/mutator methods `isOrdinal`, `getOrdinalThresholds`, and `setOrdinal`, and cloning support in `Node.clone()`.
- Extends the GUI (`ModelView`) to expose an "Ordinal variable" checkbox menu item with parsing/formatting helpers `parseOrdinalThresholds` and `formatOrdinalThresholds`, and wires the menu to call `requestSetOrdinalVariable`; integrates ordinal changes with the undo stack by detecting ordinal/threshold changes in the `popupMenuWillBecomeInvisible` handler.

### Testing

- Built the project and ran the automated test suite using the project's build tool with `mvn -DskipTests=false test`, and the existing unit tests passed. 
- Performed a project build (`mvn package`) to ensure compilation succeeds after the changes, and the build completed successfully.
- No new automated tests were added for ordinal-specific likelihoods in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d0bb573e0832c92c217b9ec4fb0b7)